### PR TITLE
fix: delete record even if file doesn't exist

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -40,7 +40,11 @@ module.exports = {
                         strapi.log.info(`File deleted. ID:${fileId}`);
                         return resolve();
                     }).catch(error => {
-                        strapi.log.error(`Unable to delete file.`);
+                        if (error.$ResponseMetadata?.statusCode === 404) {
+                            strapi.log.warn(`File not found. Proceeding with deletion. ID:${fileId}`);
+                            return resolve();
+                        }
+                        strapi.log.error(`Unable to delete file. ID:${fileId}`);
                         return reject(error);
                     });
                 });


### PR DESCRIPTION
# Description

Enables deletion of Strapi records of media files that are missing on Imagekit.

Fixes #13 



